### PR TITLE
Add CLI for anomaly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,14 @@ This project leverages Jules for building out the anomaly detection pipeline. Pl
    ```
 3. Train the autoencoder:
    ```bash
-   python -m src.train_autoencoder --epochs 5 --window-size 30 --latent-dim 16 --scaler standard
+   python -m src.train_autoencoder \
+       --epochs 5 \
+       --window-size 30 \
+       --latent-dim 16 \
+       --scaler standard \
+       --model-path saved_models/autoencoder.h5
    ```
+   The `--model-path` option controls where the trained model is written.
 4. Detect anomalies:
    ```python
    from src.anomaly_detector import AnomalyDetector
@@ -62,8 +68,21 @@ This project leverages Jules for building out the anomaly detection pipeline. Pl
    anomalies = detector.predict('data/raw/sensor_data.csv')
    print(anomalies)
    ```
+   You can also invoke anomaly detection from the command line:
+   ```bash
+   python -m src.anomaly_detector --model-path saved_models/autoencoder.h5 \
+       --csv-path data/raw/sensor_data.csv \
+       --output predictions.csv
+   ```
+   This writes a CSV file containing ``1`` for anomalous windows and ``0`` otherwise.
 5. Evaluate reconstruction error statistics:
    ```bash
-   python -m src.evaluate_model --window-size 30 --threshold-factor 3 -\
+   python -m src.evaluate_model \
+       --window-size 30 \
+       --threshold-factor 3 \
+       --model-path saved_models/autoencoder.h5 \
+       --train-epochs 1 \
        --output eval.json
    ```
+   If the model file does not exist, the script performs a training run before
+   evaluating. The number of epochs can be customized with ``--train-epochs``.

--- a/src/anomaly_detector.py
+++ b/src/anomaly_detector.py
@@ -1,11 +1,18 @@
+"""Anomaly detection utilities using a trained autoencoder."""
+
+import argparse
 import numpy as np
+import pandas as pd
 from tensorflow.keras.models import load_model
 
 from .data_preprocessor import DataPreprocessor
 
 
 class AnomalyDetector:
-    def __init__(self, model_path='saved_models/autoencoder.h5'):
+    """Compute anomaly scores and predictions using an autoencoder."""
+
+    def __init__(self, model_path: str = "saved_models/autoencoder.h5"):
+        """Load a trained model from ``model_path``."""
         self.model = load_model(model_path)
         self.preprocessor = DataPreprocessor()
 
@@ -13,9 +20,46 @@ class AnomalyDetector:
         reconstructed = self.model.predict(sequences, verbose=0)
         return np.mean(np.square(sequences - reconstructed), axis=(1, 2))
 
-    def predict(self, csv_path: str, window_size: int = 30, threshold: float = None):
+    def predict(
+        self,
+        csv_path: str,
+        window_size: int = 30,
+        threshold: float | None = None,
+    ) -> np.ndarray:
+        """Return a boolean array indicating anomalous windows."""
         windows = self.preprocessor.load_and_preprocess(csv_path, window_size)
         scores = self.score(windows)
         if threshold is None:
             threshold = scores.mean() + 3 * scores.std()
         return scores > threshold
+
+
+def main(
+    csv_path: str = "data/raw/sensor_data.csv",
+    model_path: str = "saved_models/autoencoder.h5",
+    window_size: int = 30,
+    threshold: float | None = None,
+    output_path: str = "predictions.csv",
+) -> None:
+    """Run anomaly detection on ``csv_path`` and write flags to ``output_path``."""
+    detector = AnomalyDetector(model_path)
+    preds = detector.predict(csv_path, window_size, threshold)
+    pd.Series(preds.astype(int)).to_csv(output_path, index=False, header=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Detect anomalies in a dataset")
+    parser.add_argument("--csv-path", default="data/raw/sensor_data.csv")
+    parser.add_argument("--model-path", default="saved_models/autoencoder.h5")
+    parser.add_argument("--window-size", type=int, default=30)
+    parser.add_argument("--threshold", type=float)
+    parser.add_argument("--output", default="predictions.csv")
+    args = parser.parse_args()
+
+    main(
+        csv_path=args.csv_path,
+        model_path=args.model_path,
+        window_size=args.window_size,
+        threshold=args.threshold,
+        output_path=args.output,
+    )

--- a/src/train_autoencoder.py
+++ b/src/train_autoencoder.py
@@ -12,7 +12,29 @@ def main(
     latent_dim: int = 16,
     lstm_units: int = 32,
     scaler: str | None = None,
+    model_path: str = "saved_models/autoencoder.h5",
 ):
+    """Train the LSTM autoencoder and write it to ``model_path``.
+
+    Parameters
+    ----------
+    csv_path : str
+        Sensor data CSV file used for training.
+    epochs : int, optional
+        Number of training epochs.
+    window_size : int, optional
+        Length of each sliding window of time steps.
+    latent_dim : int, optional
+        Size of the latent representation.
+    lstm_units : int, optional
+        Units for the LSTM layers.
+    scaler : str or None, optional
+        Scaling method to use. ``"standard"`` selects ``StandardScaler``; any
+        other value uses ``MinMaxScaler``.
+    model_path : str, optional
+        Destination path for saving the trained model. Parent directories are
+        created automatically.
+    """
     if scaler == "standard":
         from sklearn.preprocessing import StandardScaler
 
@@ -27,8 +49,9 @@ def main(
         lstm_units=lstm_units,
     )
     model.fit(windows, windows, epochs=epochs, batch_size=32, verbose=0)
-    Path("saved_models").mkdir(exist_ok=True)
-    model.save("saved_models/autoencoder.h5")
+    model_file = Path(model_path)
+    model_file.parent.mkdir(parents=True, exist_ok=True)
+    model.save(model_file)
 
 
 if __name__ == "__main__":
@@ -44,6 +67,11 @@ if __name__ == "__main__":
         default="minmax",
         help="Scaling method for preprocessing",
     )
+    parser.add_argument(
+        "--model-path",
+        default="saved_models/autoencoder.h5",
+        help="Where to store the trained autoencoder",
+    )
     args = parser.parse_args()
     main(
         csv_path=args.csv_path,
@@ -52,4 +80,5 @@ if __name__ == "__main__":
         latent_dim=args.latent_dim,
         lstm_units=args.lstm_units,
         scaler=args.scaler,
+        model_path=args.model_path,
     )

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -1,0 +1,41 @@
+from src import train_autoencoder
+from src.anomaly_detector import AnomalyDetector, main
+import pandas as pd
+
+
+def test_predict_flags_anomalies(tmp_path):
+    model = tmp_path / "model.h5"
+    train_autoencoder.main(
+        csv_path='data/raw/sensor_data.csv',
+        epochs=1,
+        window_size=10,
+        latent_dim=8,
+        lstm_units=16,
+        model_path=str(model),
+    )
+    detector = AnomalyDetector(str(model))
+    preds = detector.predict('data/raw/sensor_data.csv', window_size=10, threshold=0.5)
+    assert preds.dtype == bool
+    assert len(preds) > 0
+
+
+def test_cli_writes_predictions(tmp_path):
+    model = tmp_path / "model.h5"
+    output = tmp_path / "preds.csv"
+    train_autoencoder.main(
+        csv_path='data/raw/sensor_data.csv',
+        epochs=1,
+        window_size=10,
+        latent_dim=8,
+        lstm_units=16,
+        model_path=str(model),
+    )
+    main(
+        csv_path='data/raw/sensor_data.csv',
+        model_path=str(model),
+        window_size=10,
+        threshold=0.5,
+        output_path=str(output),
+    )
+    flags = pd.read_csv(output, header=None)[0]
+    assert len(flags) > 0

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -4,7 +4,22 @@ from src.evaluate_model import evaluate
 def test_evaluate_returns_stats(tmp_path):
     csv = 'data/raw/sensor_data.csv'
     out = tmp_path / 'stats.json'
-    stats = evaluate(csv_path=csv, window_size=30, threshold_factor=2.0, output_path=str(out))
+    model = tmp_path / "model.h5"
+    stats = evaluate(
+        csv_path=csv,
+        window_size=30,
+        threshold_factor=2.0,
+        output_path=str(out),
+        model_path=str(model),
+    )
     saved = json.loads(out.read_text())
     assert set(stats) == {"mse_mean", "mse_std", "threshold", "percent_anomaly"}
     assert saved == stats
+
+
+def test_evaluate_trains_if_model_missing(tmp_path):
+    csv = 'data/raw/sensor_data.csv'
+    model = tmp_path / 'autoencoder.h5'
+    assert not model.exists()
+    evaluate(csv_path=csv, model_path=str(model), train_epochs=1)
+    assert model.is_file()

--- a/tests/test_train_autoencoder.py
+++ b/tests/test_train_autoencoder.py
@@ -1,0 +1,14 @@
+from src.train_autoencoder import main
+
+
+def test_model_is_saved(tmp_path):
+    model_path = tmp_path / 'model_dir' / 'model.h5'
+    main(
+        csv_path='data/raw/sensor_data.csv',
+        epochs=1,
+        window_size=10,
+        latent_dim=8,
+        lstm_units=16,
+        model_path=str(model_path),
+    )
+    assert model_path.is_file()


### PR DESCRIPTION
## Summary
- create a command-line interface to run anomaly detection
- document the new CLI usage in the README
- add tests covering the new interface

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dfd48e8c8329b644b9a88b06fb74

## Summary by Sourcery

Introduce CLI support for anomaly detection, training, and evaluation with configurable model paths and thresholds; update README and add comprehensive tests.

New Features:
- Add command-line interface for anomaly detection with customizable input, model, window size, threshold, and output options
- Extend training script with a --model-path flag to specify where to save the trained autoencoder
- Enhance evaluation script with --model-path and --train-epochs flags and fallback training when the model file is missing

Enhancements:
- Parameterize model saving and loading paths across modules and create parent directories automatically
- Improve docstrings and unify argument parsing for consistency across scripts

Documentation:
- Document new CLI commands in README with examples for training, anomaly detection, and evaluation, including model-path and train-epochs options

Tests:
- Add tests for anomaly_detector CLI output, train_autoencoder model saving, and evaluate_model statistics and fallback training