### PR TITLE
Add quantile support for evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.0.3
+
+- Add quantile-based thresholding option to evaluation script
+- Document new CLI usage and mutually exclusive flags
+- Validate quantile bounds in `evaluate_model`
+
+## v0.0.2
+
+- Add quantile-based thresholding for anomaly detection and CLI
+- Clarify mutual exclusivity between `--threshold` and `--quantile`
+- Early validation of the `--quantile` argument in the CLI
+
 ## v0.0.1
 
 - Applying previous commit.

--- a/README.md
+++ b/README.md
@@ -82,13 +82,27 @@ This project leverages Jules for building out the anomaly detection pipeline. Pl
    ```
    You can also invoke anomaly detection from the command line:
    ```bash
-   python -m src.anomaly_detector --model-path saved_models/autoencoder.h5 \
-       --scaler-path saved_models/scaler.pkl \
-       --csv-path data/raw/sensor_data.csv \
-       --step 1 \
-       --output predictions.csv
-   ```
-   This writes a CSV file containing ``1`` for anomalous windows and ``0`` otherwise.
+  python -m src.anomaly_detector --model-path saved_models/autoencoder.h5 \
+      --scaler-path saved_models/scaler.pkl \
+      --csv-path data/raw/sensor_data.csv \
+      --step 1 \
+      --threshold 0.5 \
+      --output predictions.csv
+  ```
+  Or derive the threshold from a reconstruction error quantile instead:
+  ```bash
+  python -m src.anomaly_detector --model-path saved_models/autoencoder.h5 \
+      --scaler-path saved_models/scaler.pkl \
+      --csv-path data/raw/sensor_data.csv \
+      --step 1 \
+      --quantile 0.95 \
+      --output predictions.csv
+  ```
+  This writes a CSV file containing ``1`` for anomalous windows and ``0`` otherwise.
+  Supply either ``--threshold`` for a manual value or ``--quantile`` to derive
+  the threshold from the reconstruction error. These options are mutually
+ exclusive and ``--quantile`` must be between 0 and 1 (exclusive). Invalid
+ quantile values are rejected before the model is loaded.
 5. Evaluate reconstruction error statistics:
    ```bash
    python -m src.evaluate_model \
@@ -101,6 +115,20 @@ This project leverages Jules for building out the anomaly detection pipeline. Pl
        --train-epochs 1 \
        --output eval.json
    ```
+   Alternatively derive the threshold from a reconstruction error quantile:
+   ```bash
+   python -m src.evaluate_model \
+       --window-size 30 \
+       --step 1 \
+       --quantile 0.95 \
+       --model-path saved_models/autoencoder.h5 \
+       --scaler-path saved_models/scaler.pkl \
+       --labels-path data/raw/sensor_labels.csv \
+       --train-epochs 1 \
+       --output eval.json
+   ```
+   The ``--threshold-factor`` and ``--quantile`` options are mutually
+   exclusive. ``--quantile`` must be between 0 and 1 (exclusive).
    If the model file does not exist, the script performs a training run before
    evaluating. Providing ``--labels-path`` enables computing precision, recall
    and F1 score. The number of epochs can be customized with ``--train-epochs``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "iot_anomaly_detector_timeseries"
-version = "0.0.1"
+version = "0.0.3"
 requires-python = ">=3.8"
 
 [tool.setuptools]

--- a/src/anomaly_detector.py
+++ b/src/anomaly_detector.py
@@ -34,6 +34,7 @@ class AnomalyDetector:
         window_size: int = 30,
         step: int = 1,
         threshold: float | None = None,
+        quantile: float | None = None,
     ) -> np.ndarray:
         """Return a boolean array indicating anomalous windows.
 
@@ -46,12 +47,27 @@ class AnomalyDetector:
         step : int, optional
             Step size for the sliding window.
         threshold : float or None, optional
-            Manual threshold for anomaly detection.
+            Manual threshold for anomaly detection. If ``None`` and ``quantile``
+            is also ``None``, a threshold of ``mean + 3 * std`` is used.
+        quantile : float or None, optional
+            Quantile of the reconstruction error distribution used to derive the
+            threshold. Must be between 0 and 1 (exclusive) and is mutually
+            exclusive with ``threshold``.
         """
         windows = self.preprocessor.load_and_preprocess(csv_path, window_size, step)
         scores = self.score(windows)
+        if threshold is not None and quantile is not None:
+            raise ValueError("Provide either threshold or quantile, not both")
+
+        if quantile is not None:
+            if not 0 < quantile < 1:
+                raise ValueError("quantile must be between 0 and 1 (exclusive)")
+
         if threshold is None:
-            threshold = scores.mean() + 3 * scores.std()
+            if quantile is not None:
+                threshold = float(np.quantile(scores, quantile))
+            else:
+                threshold = scores.mean() + 3 * scores.std()
         return scores > threshold
 
 
@@ -62,19 +78,37 @@ def main(
     window_size: int = 30,
     step: int = 1,
     threshold: float | None = None,
+    quantile: float | None = None,
     output_path: str = "predictions.csv",
 ) -> None:
     """Run anomaly detection on ``csv_path`` and write flags to ``output_path``.
 
     Parameters
     ----------
+    csv_path : str, optional
+        Path to the CSV file containing the sensor data.
+    model_path : str, optional
+        Path to the trained autoencoder model.
+    window_size : int, optional
+        Length of each sliding window.
     scaler_path : str or None, optional
         Path to a saved scaler fitted during training.
     step : int, optional
         Step size for the sliding window.
+    threshold : float or None, optional
+        Manual threshold for anomaly detection.
+    quantile : float or None, optional
+        Quantile-based threshold to use instead of ``threshold``. The value must
+        be between 0 and 1 (exclusive) and cannot be combined with
+        ``threshold``.
+    output_path : str, optional
+        Where to write the anomaly flags as a CSV file.
     """
     detector = AnomalyDetector(model_path, scaler_path)
-    preds = detector.predict(csv_path, window_size, step, threshold)
+    if quantile is not None and not 0 < quantile < 1:
+        raise ValueError("quantile must be between 0 and 1 (exclusive)")
+
+    preds = detector.predict(csv_path, window_size, step, threshold, quantile)
     pd.Series(preds.astype(int)).to_csv(output_path, index=False, header=False)
 
 
@@ -94,7 +128,20 @@ if __name__ == "__main__":
         default=1,
         help="Step size for sliding windows",
     )
-    parser.add_argument("--threshold", type=float)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--threshold",
+        type=float,
+        help="Manual threshold for anomaly detection",
+    )
+    group.add_argument(
+        "--quantile",
+        type=float,
+        help=(
+            "Quantile of reconstruction error used for the threshold. "
+            "Must be between 0 and 1 (exclusive)."
+        ),
+    )
     parser.add_argument("--output", default="predictions.csv")
     args = parser.parse_args()
 
@@ -105,5 +152,6 @@ if __name__ == "__main__":
         window_size=args.window_size,
         step=args.step,
         threshold=args.threshold,
+        quantile=args.quantile,
         output_path=args.output,
     )

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -7,6 +7,8 @@ pytest.importorskip("tensorflow")
 from src import train_autoencoder
 from src.anomaly_detector import AnomalyDetector, main
 import pandas as pd
+import subprocess
+import sys
 
 
 def test_predict_flags_anomalies(tmp_path):
@@ -25,6 +27,63 @@ def test_predict_flags_anomalies(tmp_path):
     preds = detector.predict('data/raw/sensor_data.csv', window_size=10, step=2, threshold=0.5)
     assert preds.dtype == bool
     assert len(preds) > 0
+
+
+def test_predict_with_quantile(tmp_path):
+    model = tmp_path / "model.h5"
+    train_autoencoder.main(
+        csv_path='data/raw/sensor_data.csv',
+        epochs=1,
+        window_size=10,
+        step=2,
+        latent_dim=8,
+        lstm_units=16,
+        model_path=str(model),
+        scaler_path=str(tmp_path / "scaler.pkl"),
+    )
+    detector = AnomalyDetector(str(model), str(tmp_path / "scaler.pkl"))
+    preds = detector.predict(
+        'data/raw/sensor_data.csv', window_size=10, step=2, quantile=0.9
+    )
+    assert preds.dtype == bool
+    assert len(preds) > 0
+
+
+@pytest.mark.parametrize("bad_quantile", [1.5, 1.0, 0.0, -0.2])
+def test_quantile_validation(tmp_path, bad_quantile):
+    model = tmp_path / "model.h5"
+    train_autoencoder.main(
+        csv_path='data/raw/sensor_data.csv',
+        epochs=1,
+        window_size=10,
+        step=2,
+        latent_dim=8,
+        lstm_units=16,
+        model_path=str(model),
+        scaler_path=str(tmp_path / "scaler.pkl"),
+    )
+    detector = AnomalyDetector(str(model), str(tmp_path / "scaler.pkl"))
+    with pytest.raises(ValueError):
+        detector.predict('data/raw/sensor_data.csv', step=2, quantile=bad_quantile)
+
+
+def test_threshold_and_quantile_exclusive(tmp_path):
+    model = tmp_path / "model.h5"
+    train_autoencoder.main(
+        csv_path='data/raw/sensor_data.csv',
+        epochs=1,
+        window_size=10,
+        step=2,
+        latent_dim=8,
+        lstm_units=16,
+        model_path=str(model),
+        scaler_path=str(tmp_path / "scaler.pkl"),
+    )
+    detector = AnomalyDetector(str(model), str(tmp_path / "scaler.pkl"))
+    with pytest.raises(ValueError):
+        detector.predict(
+            'data/raw/sensor_data.csv', step=2, threshold=0.5, quantile=0.9
+        )
 
 
 def test_cli_writes_predictions(tmp_path):
@@ -46,8 +105,64 @@ def test_cli_writes_predictions(tmp_path):
         scaler_path=str(tmp_path / "scaler.pkl"),
         window_size=10,
         step=2,
-        threshold=0.5,
+        quantile=0.9,
         output_path=str(output),
     )
     flags = pd.read_csv(output, header=None)[0]
     assert len(flags) > 0
+
+
+def test_cli_threshold_and_quantile_exclusive(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.anomaly_detector",
+            "--csv-path",
+            "data/raw/sensor_data.csv",
+            "--model-path",
+            str(tmp_path / "model.h5"),
+            "--scaler-path",
+            str(tmp_path / "scaler.pkl"),
+            "--window-size",
+            "10",
+            "--step",
+            "2",
+            "--threshold",
+            "0.5",
+            "--quantile",
+            "0.9",
+            "--output",
+            str(tmp_path / "out.csv"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_cli_invalid_quantile(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.anomaly_detector",
+            "--csv-path",
+            "data/raw/sensor_data.csv",
+            "--model-path",
+            str(tmp_path / "model.h5"),
+            "--scaler-path",
+            str(tmp_path / "scaler.pkl"),
+            "--window-size",
+            "10",
+            "--step",
+            "2",
+            "--quantile",
+            "1.2",
+            "--output",
+            str(tmp_path / "out.csv"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0

--- a/tests/test_evaluate_model.py
+++ b/tests/test_evaluate_model.py
@@ -26,6 +26,20 @@ def test_evaluate_returns_stats(tmp_path):
     assert saved == stats
 
 
+def test_evaluate_with_quantile(tmp_path):
+    csv = 'data/raw/sensor_data.csv'
+    model = tmp_path / 'model.h5'
+    stats = evaluate(
+        csv_path=csv,
+        window_size=30,
+        step=2,
+        quantile=0.9,
+        model_path=str(model),
+        scaler_path=str(tmp_path / 'scaler.pkl'),
+    )
+    assert "threshold" in stats
+
+
 def test_evaluate_trains_if_model_missing(tmp_path):
     csv = 'data/raw/sensor_data.csv'
     model = tmp_path / 'autoencoder.h5'
@@ -54,3 +68,17 @@ def test_evaluate_with_labels(tmp_path):
         train_epochs=1,
     )
     assert {"precision", "recall", "f1"}.issubset(stats)
+
+
+@pytest.mark.parametrize("bad_q", [1.1, 0.0, -0.3])
+def test_evaluate_invalid_quantile(tmp_path, bad_q):
+    csv = 'data/raw/sensor_data.csv'
+    model = tmp_path / 'bad.h5'
+    with pytest.raises(ValueError):
+        evaluate(
+            csv_path=csv,
+            step=2,
+            quantile=bad_q,
+            model_path=str(model),
+            scaler_path=str(tmp_path / 'scaler.pkl'),
+        )


### PR DESCRIPTION
## Summary
- add optional `--quantile` to `evaluate_model` with bounds checking
- make threshold calculation mutually exclusive with `--threshold-factor`
- document quantile-based evaluation workflow in README
- bump version to 0.0.3 and update changelog
- test evaluation with quantile and invalid bounds

## Testing
- `ruff check .`
- `bandit -r src | head -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68600028ce9c8329ac901163304812ea

## Summary by Sourcery

Add optional quantile-based thresholding for anomaly detection and evaluation workflows, enforce mutual exclusivity and valid bounds, update documentation and tests, and bump version.

New Features:
- Add optional quantile parameter to derive thresholds from reconstruction error distributions in both prediction and evaluation.

Enhancements:
- Enforce mutual exclusivity between threshold and quantile options in CLI and API.
- Validate that quantile values are strictly between 0 and 1 and derive thresholds from quantiles when provided.

Build:
- Bump project version to 0.0.3 and update CHANGELOG.md.

Documentation:
- Document quantile-based thresholding workflow and mutual exclusivity in README.

Tests:
- Add tests for quantile-based prediction and evaluation, invalid quantile bounds, and mutual exclusivity with threshold in both CLI and API.